### PR TITLE
Organize project with standard Python layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# VSCode settings
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Astral Oddities
+
+A starter project demonstrating best-practice project structure.
+
+## Features
+
+- Organized source code under `src/`
+- Tests using `pytest`
+- Documentation in `docs/`
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# Documentation
+
+Project documentation will live here.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "astral-oddities"
+version = "0.1.0"
+description = "Starter project for Astral Oddities"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src
+

--- a/src/astral_oddities/__init__.py
+++ b/src/astral_oddities/__init__.py
@@ -1,0 +1,6 @@
+"""Astral Oddities package."""
+
+from .core import greet
+
+__all__ = ["greet"]
+

--- a/src/astral_oddities/core.py
+++ b/src/astral_oddities/core.py
@@ -1,0 +1,7 @@
+"""Core functionality for Astral Oddities."""
+
+
+def greet(name: str) -> str:
+    """Return a friendly greeting."""
+    return f"Welcome to Astral Oddities, {name}!"
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,6 @@
+from astral_oddities import greet
+
+
+def test_greet():
+    assert greet("Explorer") == "Welcome to Astral Oddities, Explorer!"
+


### PR DESCRIPTION
## Summary
- scaffold project structure with src, docs, and tests directories
- add simple greeting function and corresponding unit test
- configure packaging via pyproject.toml and pytest with pythonpath

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689129328d488324a2125986d9ce92ba